### PR TITLE
Add multi-stage Dockerfile for production builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # IDE specific files
 .idea/
+maxscale_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM golang:1.8 AS build
 
-COPY maxscale_exporter /bin/maxscale_exporter
+WORKDIR /go/src/app
+COPY . .
+RUN go get -d -v ./...
+RUN go install -v ./...
+RUN go get github.com/RubenHoms/maxscale_exporter
+RUN make build
 
-ENTRYPOINT  ["/bin/maxscale_exporter"]
-USER        nobody
-EXPOSE      9195
+FROM alpine:3.10
+
+COPY --from=build /go/src/app/maxscale_exporter /bin/maxscale_exporter
+USER nobody
+EXPOSE 9195
+ENTRYPOINT ["/bin/maxscale_exporter"]


### PR DESCRIPTION
Modified the `Dockerfile` and added a build stage. Update the final image to use `alpine:3.10`. 

I am a little bit unsure about this line and what is does: 
`RUN go get github.com/RubenHoms/maxscale_exporter`

I am not really a go expert. Is this needed as you already inject the source by the COPY step? What does it exactly add? I see the build fails without it. 