### PR TITLE
Append underscore to envPrefix

### DIFF
--- a/maxscale_exporter.go
+++ b/maxscale_exporter.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	envPrefix   = "MAXSCALE_EXPORTER"
+	envPrefix   = "MAXSCALE_EXPORTER_"
 	metricsPath = "/metrics"
 	namespace   = "maxscale"
 )


### PR DESCRIPTION
Fixes parsing env vars

Before, it wasn't actually reading env vars like MAXSCALE_EXPORTER_ADDRESS as described in the documentation but env vars like MAXSCALE_EXPORTERADDRESS instead. This fixes that.